### PR TITLE
trying to type check flip

### DIFF
--- a/theories/clutch/examples/counterexample2.v
+++ b/theories/clutch/examples/counterexample2.v
@@ -1,0 +1,55 @@
+From stdpp Require Export stringmap fin_map_dom gmap.
+From clutch Require Export clutch clutch.lib.flip clutch.lib.conversion.
+From clutch.common Require Import exec.
+From clutch.prob_lang.typing Require Import tychk.
+
+Set Default Proof Using "Type*".
+
+(** If we assume that we can freely pick presampling tapes to read from when
+    resolving probabilistic choices, we can show refinements/equivalences that
+    do not hold. *)
+Section counterexample_annotation.
+  Context `{!clutchRGS Σ}.
+
+  Definition refines_tape_unsound :=
+    ∀ K E (A : lrel Σ) α N n ns e',
+    α ↪ (N; n::ns) ∗
+    (α ↪ (N; ns) -∗  REL fill K (Val #n) << e' @ E : A)
+    ⊢ REL fill K (rand #N) << e' @ E : A.
+  Print refines_tape_unsound.
+
+  Definition flip : expr := rand #1.
+
+  Definition flip_ors : expr :=
+    let: "x" := rand #1 in
+    let: "y" := rand #1 in
+    if: "x" = #1 then #1 else "y".
+
+  Lemma counterexample_annotation α1 α2 :
+    refines_tape_unsound →
+    (α1 ↪ (1%nat; [])) ∗ (α2 ↪ (1%nat; []))
+    ⊢ REL flip << flip_ors  : lrel_int.
+  Proof.
+    iIntros (refines_tape_unsound) "[Hα1 Hα2]". rewrite /flip_ors /flip.
+    rel_apply (refines_couple_tape_rand _ _ _ _ _ α1); iFrame.
+    iIntros (n1) "Hα1 /=".
+    rel_pures_r.
+    rel_apply (refines_couple_tape_rand _ _ _ _ _ α2); iFrame.
+    iIntros (n2) "Hα2 /=".
+    rel_pures_r.
+    case_bool_decide.
+    - rewrite -H. rel_apply (refines_tape_unsound _ _ _ α1).
+      (* TODO: how to rewrite this H' *)
+      admit.
+    - admit. (* TODO: not sure how to apply the other lemma.. *)
+      (* rel_apply (refines_tape_unsound _ _ _ α2). *)
+
+
+
+  Admitted.
+
+
+End counterexample_annotation.
+
+
+

--- a/theories/clutch/lib/flip.v
+++ b/theories/clutch/lib/flip.v
@@ -500,24 +500,81 @@ Proof.
   rewrite lim_exec_val_rw.
   rewrite mon_sup_succ.
   - erewrite <-sup_seq_const. do 2 f_equal. apply functional_extensionality_dep.
+    (* TODO: what is this `=>` for? Doesnt' seem to have any effect? *)
     intros n. simpl. rewrite head_prim_step_eq => /=.
-Admitted.
+    rewrite /dmap /dunifP.
+    assert ( (S (Z.to_nat 1%nat)) = 2%nat) as H by done.
+    rewrite H.
+    rewrite -dbind_assoc -/exec_val.
+    rewrite {1}/dbind/pmf/dbind_pmf.
+    f_equal. rewrite SeriesC_scal_l. (* oh shit this is really cool... *)
+    setoid_rewrite dret_id_left. (* TODO: make sure when to use setoid rewrite... *)
+
+    assert (SeriesC (λ x : fin 2, exec_val n (Val #x, σ) #0) = 1%R).
+    * rewrite SeriesC_fin2.
+      do 2 (erewrite exec_val_is_val; auto).
+      do 2 rewrite dret_pmf_unfold.
+      case_bool_decide; auto.
+      -- case_bool_decide.
+      --- inversion H1.
+      --- real_solver.
+      -- case_bool_decide; auto.
+      --- inversion H1.
+      --- done. (* TODO: wait how is this solved by done??? *)
+    * rewrite H0. real_solver.
+  - intro. apply exec_val_mon.
+Qed.
+
+Lemma lim_exec_val_rand_3 σ:
+  lim_exec_val ((rand(#()) #1%nat)%E, σ) #3 = 0.
+Proof.
+  rewrite lim_exec_val_rw.
+  rewrite mon_sup_succ.
+  - erewrite <-sup_seq_const. do 2 f_equal. apply functional_extensionality_dep.
+    (* TODO: what is this `=>` for? Doesnt' seem to have any effect? *)
+    intros n. simpl. rewrite head_prim_step_eq => /=.
+    rewrite /dmap /dunifP.
+    assert ( (S (Z.to_nat 1%nat)) = 2%nat) as H by done.
+    rewrite H.
+    rewrite -dbind_assoc -/exec_val.
+    rewrite {1}/dbind/pmf/dbind_pmf.
+    f_equal. apply SeriesC_0. intros x.
+    rewrite dret_id_left => /=.
+    replace (exec_val _ _ _) with 0%R; [lra|].
+    erewrite exec_val_is_val; auto.
+    rewrite dret_pmf_unfold.
+    case_bool_decide; auto.
+    inversion H0.
+    exfalso.
+    assert (fin_to_nat x < 2)%nat as Hlt.
+    { 
+      (* TODO: importing this globally will break things.. *)
+      From stdpp Require Import fin.
+      apply fin_to_nat_lt. 
+    }
+    lia.
+  - intro. apply exec_val_mon.
+    (* rewrite (SeriesC_split_pred _ (λ x, bool_decide (x.2=0%nat))); last first. *)
+Qed.
 
 
 Lemma lim_exec_rand σ :
   lim_exec ((rand(#()) #1%nat)%E, σ) #0 = (1/2)%R.
 Proof.
-  (* TODO: why does this work?? *)
   apply (lim_exec_val_rand σ).
 Qed.
 
-
 Lemma lim_exec_flip σ :
-  lim_exec (flip, σ) #false = (1/2)%R.
+  lim_exec_val ((flipL #())%E, σ) #true = (1/2)%R.
 Proof.
-  rewrite /flip/flipL.
-  erewrite (lim_exec_term 10).
-  - simpl.
-    rewrite /int_to_bool.
+  rewrite /flipL.
+  rewrite /int_to_bool.
+  rewrite lim_exec_val_rw.
+  rewrite mon_sup_succ.
+  - erewrite <-sup_seq_const. do 2 f_equal. apply functional_extensionality_dep.
+    intros n. simpl. rewrite head_prim_step_eq => /=.
+    (* TODO: not sure how to proceed *)
     admit.
+  - intro. apply exec_val_mon.
 Admitted.
+

--- a/theories/clutch/lib/flip.v
+++ b/theories/clutch/lib/flip.v
@@ -3,6 +3,12 @@ From stdpp Require Import namespaces.
 From iris.proofmode Require Import
   coq_tactics ltac_tactics sel_patterns environments reduction proofmode.
 From clutch Require Import clutch clutch.lib.conversion.
+From clutch.common Require Import exec.
+
+(* TODO: importing the following will cause chaos *)
+(* From clutch.prob Require Import distribution. *)
+(* From Coquelicot Require Import Rcomplements Rbar Lim_seq. *)
+
 
 Definition flipL : val := λ: "e", int_to_bool (rand("e") #1%nat).
 Definition flip : expr := (flipL #()).
@@ -487,3 +493,31 @@ Tactic Notation "rel_flipL_r" :=
   |rel_finish  (** new goal *)].
 
 Global Opaque tapeB.
+
+Lemma lim_exec_val_rand σ:
+  lim_exec_val ((rand(#()) #1%nat)%E, σ) #0 = (1/2)%R.
+Proof.
+  rewrite lim_exec_val_rw.
+  rewrite mon_sup_succ.
+  - erewrite <-sup_seq_const. do 2 f_equal. apply functional_extensionality_dep.
+    intros n. simpl. rewrite head_prim_step_eq => /=.
+Admitted.
+
+
+Lemma lim_exec_rand σ :
+  lim_exec ((rand(#()) #1%nat)%E, σ) #0 = (1/2)%R.
+Proof.
+  (* TODO: why does this work?? *)
+  apply (lim_exec_val_rand σ).
+Qed.
+
+
+Lemma lim_exec_flip σ :
+  lim_exec (flip, σ) #false = (1/2)%R.
+Proof.
+  rewrite /flip/flipL.
+  erewrite (lim_exec_term 10).
+  - simpl.
+    rewrite /int_to_bool.
+    admit.
+Admitted.

--- a/theories/common/exec.v
+++ b/theories/common/exec.v
@@ -109,6 +109,7 @@ Section exec_val.
   Implicit Types v : val Λ.
   Implicit Types σ : state Λ.
 
+  (* TODO: what is this `{struct n}` *)
   Fixpoint exec_val (n : nat) (ρ : cfg Λ) {struct n} : distr (val Λ) :=
     match to_val ρ.1, n with
       | Some v, _ => dret v

--- a/theories/prob_lang/typing/contextual_refinement_alt.v
+++ b/theories/prob_lang/typing/contextual_refinement_alt.v
@@ -406,8 +406,7 @@ Proof.
          f_equal. apply SeriesC_0. intros [??].
          rewrite dret_id_left => /=.
          replace (exec_val _ _ _) with 0; [lra|].
-         do 2 f_equal.
-         rewrite <- Rbar_finite_eq.
+         rewrite -Rbar_finite_eq.
          by rewrite IHn.
 Qed.
 
@@ -436,17 +435,3 @@ Proof.
     rewrite /K' /=.
     by do 2 rewrite -alt_impl_ctx_refines_loop_lemma.
 Qed.
-
-Lemma lim_exec_val_rand σ:
-  lim_exec_val ((rand(#()) #1%nat)%E, σ) #3 = 0.
-Proof.
-  rewrite lim_exec_val_rw.
-  rewrite mon_sup_succ.
-  - erewrite <-sup_seq_const. do 2 f_equal. apply functional_extensionality_dep.
-  (* TODO: what is this `=>` for? Doesnt' seem to have any effect? *)
-    intros n. simpl. rewrite head_prim_step_eq => /=.
-    rewrite /dmap /dunifP.
-    assert ( (S (Z.to_nat 1%nat)) = 2%nat) as H by done.
-    rewrite H.
-    rewrite dunif_fair_conv_comb.
-Admitted.

--- a/theories/prob_lang/typing/contextual_refinement_alt.v
+++ b/theories/prob_lang/typing/contextual_refinement_alt.v
@@ -287,7 +287,7 @@ Lemma lim_exec_val_of_val_true_one (e : expr) σ :
   e = #true →
   lim_exec_val ((if: e then #() else loop)%E, σ) (#()) = 1.
 Proof.
-intros ->.
+  intros ->.
   rewrite lim_exec_val_rw.
   rewrite mon_sup_succ.
   - erewrite <-sup_seq_const. do 2 f_equal. apply functional_extensionality_dep.
@@ -436,3 +436,17 @@ Proof.
     rewrite /K' /=.
     by do 2 rewrite -alt_impl_ctx_refines_loop_lemma.
 Qed.
+
+Lemma lim_exec_val_rand σ:
+  lim_exec_val ((rand(#()) #1%nat)%E, σ) #3 = 0.
+Proof.
+  rewrite lim_exec_val_rw.
+  rewrite mon_sup_succ.
+  - erewrite <-sup_seq_const. do 2 f_equal. apply functional_extensionality_dep.
+  (* TODO: what is this `=>` for? Doesnt' seem to have any effect? *)
+    intros n. simpl. rewrite head_prim_step_eq => /=.
+    rewrite /dmap /dunifP.
+    assert ( (S (Z.to_nat 1%nat)) = 2%nat) as H by done.
+    rewrite H.
+    rewrite dunif_fair_conv_comb.
+Admitted.

--- a/theories/pure_complete/eris_ast.v
+++ b/theories/pure_complete/eris_ast.v
@@ -1,7 +1,53 @@
 From clutch.eris Require Export eris error_rules. 
 From clutch.pure_complete Require Import pure term.
+Import Coquelicot.Lim_seq.
 
 Local Open Scope R.
+
+Lemma prob_comp_nn `{Countable A} (μ : distr A) (f : A -> bool) : 0 <= 1 - prob μ f.
+Proof.
+  pose proof (prob_le_1 μ f). lra.
+Qed.
+
+Definition prob_comp_nnr `{Countable A} (μ : distr A) (f : A -> bool) : nonnegreal := mknonnegreal (1 - prob μ f) (prob_comp_nn _ _).
+
+Lemma tgl_gt_lim (e : expr) σ φ ε ε' : 
+  ε < ε' ->
+  tgl (lim_exec (e, σ)) φ ε -> 
+  ∃ n, tgl (exec n (e, σ)) φ ε'.
+Proof.
+  rewrite /tgl //= /prob.  
+  intros. 
+  Check lim_exec_unfold.
+  assert ((λ a : val, if bool_decide (φ a) then lim_exec (e, σ) a else 0) = (λ a : val, Rbar.real $ Sup_seq (λ n, Rbar.Finite $ if bool_decide (φ a) then exec n (e,σ) a else 0))). {
+    apply functional_extensionality => a //=.
+    case_bool_decide; last by rewrite sup_seq_const.
+    by rewrite lim_exec_unfold.
+  }
+  rewrite H1 in H0.
+  erewrite SeriesC_Sup_seq_swap in H0; first last; intros.
+  
+  2 : { eapply SeriesC_correct. eapply ex_seriesC_le; real_solver.  }
+  { simpl. etrans; first eapply SeriesC_le; real_solver. }
+  { exists 1. real_solver. }
+  { case_bool_decide; try lra. apply exec_mono.  }
+  { real_solver. }
+  
+  set s := Rbar.real $ Sup_seq (λ n : nat,  Rbar.Finite (SeriesC (λ a : val, if bool_decide (φ a) then exec n (e, σ) a else 0))).
+
+  assert (Lim_seq.is_sup_seq (λ n : nat, Rbar.Finite (SeriesC (λ a : val, if bool_decide (φ a) then exec n (e, σ) a else 0)))  (Rbar.Finite $ s)). {
+    rewrite rbar_finite_real_eq. 2 : {
+      apply (Rbar_le_sandwich 0 1).
+      { apply (Sup_seq_minor_le _ _ 0%nat). apply SeriesC_ge_0; try real_solver. eapply ex_seriesC_le; try real_solver.  }
+      { apply upper_bound_ge_sup => n //=. etrans; first eapply SeriesC_le; real_solver. }
+    }
+    apply Lim_seq.Sup_seq_correct.
+  }
+  unfold is_sup_seq in H2.
+  assert (0 < s - (1 - ε')); first by rewrite /s; lra.
+  specialize H2 with (mkposreal _ H3) as [?[n?]].
+  exists n. simpl in H4. ring_simplify in H4. ring_simplify. lra.
+Qed.
 
 Section Complete.
 
@@ -124,6 +170,152 @@ Section Complete.
       }
   Qed.
 
+   Lemma AST_complete_pure_pre' (n: nat) (e : expr) (σ : state) φ ε E : 
+    is_pure e = true -> 
+    tgl (exec n (e, σ)) φ ε ->
+    ↯ ε -∗ WP e @ E [{ v, ⌜φ v⌝ }].
+  Proof. 
+    intros.
+    iInduction n as [|n] "IH" forall (e H σ ε H0).
+    - rewrite /exec //= in H0.
+      destruct (to_val e) eqn: He.
+      + iIntros "Herr". 
+        rewrite /tgl in H0. apply of_to_val in He as <-.
+        destruct (bool_decide (φ v)) eqn: Hv.
+        -- rewrite prob_dret_true //= in H0.
+           wp_pures. iModIntro. iPureIntro. by eapply bool_decide_eq_true_1.
+        -- rewrite prob_dret_false //= in H0.
+           iPoseProof (ec_contradict with "Herr") as "H"; auto; lra.
+      + iIntros "Herr". 
+        rewrite /tgl in H0. 
+        assert (prob dzero (λ (a : val), bool_decide (φ a)) = 0). {
+          rewrite /prob. erewrite SeriesC_ext; first by rewrite SeriesC_0.
+          move => ? //=. by case_bool_decide.
+        }
+        rewrite H1 in H0.
+        iPoseProof (ec_contradict with "Herr") as "H"; auto; lra.
+        
+    - destruct (language.to_val e) eqn: He.
+      { iIntros "Herr". 
+        rewrite /tgl in H0. apply of_to_val in He as <-.
+        destruct (bool_decide (φ v)) eqn: Hv.
+        -- rewrite prob_dret_true //= in H0.
+           wp_pures. iModIntro. iPureIntro. by eapply bool_decide_eq_true_1.
+        -- rewrite prob_dret_false //= in H0.
+           iPoseProof (ec_contradict with "Herr") as "H"; auto; lra. }
+      iIntros "Herr".
+      iApply twp_lift_step_fupd_glm; auto.
+      iIntros "%% [Hs Herra]". 
+      iDestruct (ec_supply_ec_inv with "Herra Herr") as %(ε1' & ε3 & Hε_now & Hε1').
+      iApply fupd_mask_intro.
+      { set_solver. }
+      iIntros "hclose".
+      iApply glm_adv_comp. 
+      iExists (fun s => step (e, σ1) s > 0), 0%NNR, (fun x => (ε3 + prob_comp_nnr (exec n x) (λ a, bool_decide (φ a)))%NNR).
+      destruct (Rlt_dec 0 (prob (exec (S n) (e, σ)) (λ x, bool_decide (φ x)))).
+      2 : {
+        iExFalso.
+        iApply (ec_contradict with "Herr").
+        rewrite /pterm_comp. simpl. 
+        rewrite /tgl in H0. lra.
+      }
+      iSplitR.
+      { 
+        iPureIntro. 
+        eapply pure_reducible => //=.
+        apply mass_pos_reducible.
+        destruct (decide (SeriesC (step (e, σ)) <= 0)); try real_solver.
+        apply Rle_antisym in r0; auto. rewrite exec_Sn step_or_final_no_final in r; auto.
+        symmetry in r0. apply SeriesC_zero_dzero in r0.
+        rewrite r0 dbind_dzero in r. 
+        assert (prob dzero (λ (a : val), bool_decide (φ a)) = 0). {
+          rewrite /prob. erewrite SeriesC_ext; first by rewrite SeriesC_0.
+          move => ? //=. by case_bool_decide.
+        } 
+        rewrite H1 in r. lra.
+      }
+      iSplitR. {
+        iPureIntro. exists (ε3+1).
+        intros. simpl.
+        apply Rplus_le_compat_l, Rminus_le_0_compat, prob_ge_0.
+      }
+      iSplitR. {
+        iPureIntro.
+        simpl. rewrite Rplus_0_l. 
+        rewrite (SeriesC_ext _ (λ r, (λ a, (prim_step e σ1 a) * (ε3 + 1)) r + (-1) * (λ a,  (prim_step e σ1 a) * prob (exec n a) (λ a : val, bool_decide (φ a))) r)).
+        2: {
+          intros.
+          field_simplify. real_solver.
+        }
+        rewrite (SeriesC_plus).
+        2 : {
+          apply ex_seriesC_scal_r. apply pmf_ex_seriesC.
+        }
+        2 : {
+          apply ex_seriesC_scal_l.
+          apply pmf_ex_seriesC_mult_fn. 
+          exists 1. intros. split.
+          - apply prob_ge_0.
+          - apply prob_le_1.
+        }
+        rewrite Hε_now. replace (nonneg (ε1' + ε3)%NNR) with (nonneg ε1' + ε3); auto.
+        rewrite Hε1'.
+        rewrite SeriesC_scal_l SeriesC_scal_r.
+        rewrite /step. simpl. field_simplify.
+        rewrite <- Rplus_minus_assoc.
+        apply Rplus_le_compat.
+        { rewrite <- Rmult_1_l. apply Rmult_le_compat_r; auto. }
+        rewrite /tgl in H0.
+        assert (1 - prob (exec (S n) (e, σ)) (λ a : mstate_ret (lang_markov prob_lang), bool_decide (φ a)) <= ε); try lra.
+        etrans. 2 : apply H1.
+        rewrite !Rminus_def.
+        apply Rplus_le_compat; auto.
+        apply Ropp_le_contravar. 
+        rewrite <- prob_dbind. 
+        assert ((dbind (exec n) (prim_step e σ1))= (exec (S n) (e, σ))) as <-; try real_solver.
+        erewrite pure_exec_state; auto.
+        simpl. by rewrite He.
+      }
+      iSplitR.
+      { 
+        iPureIntro.
+        simpl.
+        apply (pgl_mon_pred _ (fun x => (fun _ => True) x ∧ (prim_step e σ1) x > 0)).
+        - by intros a [_ Hp]. 
+        - apply pgl_pos_R, pgl_trivial. lra.
+      }
+      iIntros. 
+      iMod (ec_supply_decrease with "Herra Herr") as (????) "Herra".
+      iModIntro.
+      destruct (Rlt_decision (nonneg ε3 + nonneg (prob_comp_nnr (exec n (e2, σ2)) (λ a : val, bool_decide (φ a))))%R 1%R) as [Hdec|Hdec]; last first.
+      { 
+        apply Rnot_lt_ge, Rge_le in Hdec.
+        iApply exec_stutter_spend.
+        iPureIntro.
+        simpl.
+        simpl in Hdec. lra.
+      }
+      iApply exec_stutter_free.
+      iMod (ec_supply_increase ε3 (prob_comp_nnr (exec n (e2, σ2)) (λ a : val, bool_decide (φ a))) with "[Herra]") as "[Herra Herr]"; try lra.
+      { iApply ec_supply_eq; [|done]. simplify_eq. lra. }
+      simpl in H0. 
+      apply (pure_state_step) in H1 as H'1; auto.
+      subst σ2.
+      iFrame.
+      iMod "hclose".
+      iApply fupd_mask_intro.
+      { set_solver. }
+      iIntros.
+      iApply "IH"; iFrame.
+      { 
+        iPureIntro. eapply pure_step_inv. 
+        - apply H.
+        - apply H1.
+      }
+      iPureIntro. rewrite /tgl /prob_comp_nnr =>//=. 
+      by field_simplify.
+  Qed.
+
   Theorem AST_complete_pure (e : expr) ε: 
     is_pure e = true ->
     almost_surely_terminates (e, σ₀) ->
@@ -139,4 +331,65 @@ Section Complete.
     - by iApply AST_complete_pure_pre.
   Qed.
 
+
+  Theorem twp_complete_pure (e : expr) ε φ: 
+    is_pure e = true ->
+    tgl (lim_exec (e, σ₀)) φ ε ->
+    ↯ ε -∗ WP e [{ v, ⌜φ v⌝ }].
+  Proof.
+    iIntros "%% Herr".
+    destruct (to_val e) eqn: He.
+    { 
+      apply of_to_val in He; subst.
+      rewrite /tgl /prob in H0. 
+      destruct (decide (φ v)); first by wp_pures.
+      rewrite SeriesC_0 in H0. 2 : {
+        intros. case_bool_decide; auto.
+        erewrite lim_exec_final; auto.
+        eapply dret_0. destruct (decide (x = v)); subst; eauto.
+      }
+      iPoseProof (ec_contradict with "Herr") as "H"; auto; lra.
+    }
+    iApply twp_lift_step_fupd_glm; auto.
+    iIntros "%% [Hs Herra]". 
+    iApply fupd_mask_intro.
+    { set_solver. }
+    iIntros "hclose".
+    iApply glm_err_incr_step.
+    iIntros. 
+    iMod "hclose".
+    iDestruct (ec_supply_ec_inv with "Herra Herr") as %(ε1' & ε3 & Hε_now & Hε1'); subst.
+    assert (∃ ε2, (ε1' + ε3 + ε2)%NNR = ε') as [??]. { 
+      assert (0 <= ε' - (ε1' + ε3)); first by apply Rle_0_le_minus; real_solver.
+      exists (mknonnegreal _ H2). 
+      apply nnreal_ext => //=. real_solver.
+    } 
+    assert (0 < x). { 
+      rewrite -H2 //= in H1. 
+      apply (Rplus_lt_reg_l (ε1' + ε3)). 
+      by field_simplify.
+    }
+    subst.
+    destruct (decide (ε1' + ε3 + x < 1)) as [H2 | H2]. 2 : { 
+      apply Rnot_lt_ge, Rge_le in H2.
+      iApply exec_stutter_spend.
+      iApply fupd_mask_intro.
+      { set_solver. }
+      iIntros.
+      by iPureIntro.
+    }
+    iMod (ec_supply_increase with "Herra") as "[Herra Herr']"; first by simpl; exact H2.
+    iCombine "Herr" "Herr'" as "Herr".
+    assert (ε1' < ε1' + x). { lra. }
+    eapply tgl_gt_lim in H0 as [n H0]; [|exact H4].
+    iPoseProof (AST_complete_pure_pre' with "Herr") as "hwp"; eauto.
+    rewrite tgl_wp_unfold /tgl_wp_pre //= He.
+    iPoseProof ("hwp" with "[Hs Herra]") as "hwp"; try iFrame.
+    iMod "hwp". 
+    iApply fupd_mask_intro. 
+    { set_solver. }
+    iIntros "Hclose'".
+    iApply exec_stutter_free.
+    iFrame.
+  Qed.
 End Complete.


### PR DESCRIPTION
~~You can't syntactically type `flip`.~~

```coq
Definition flip : expr := (flipL #()).
Definition flipL : val := λ: "e", int_to_bool (rand("e") #1%nat).
Definition int_to_bool : val :=
  λ: "z",
    if: "z" = #0 then #false      
    else #true.
```

~~Since `z` must be `int` type as there's no `LitNat`, but `rand _ _` returns `TNat`~~

~~There are several ways to fix this:~~
~~1. add `LitNat`~~
~~2. add new typing rules `BinOp_typed_nat`, but I realized I need to make more changes... this is not done yet~~
~~3. add subtyping rule from `TNat : TInt`~~ Philip already added this in Aug 2024
~~4. Remove `TNat`~~

~~Philip suggested just remove `TNat`, since adding the subtyping rule creates complications in `tychk`~~
